### PR TITLE
Fix recipe unlock condition

### DIFF
--- a/src/main/resources/data/explorerscompass/advancements/explorers_compass.json
+++ b/src/main/resources/data/explorerscompass/advancements/explorers_compass.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:compass"
+            "items": ["minecraft:compass"]
           }
         ]
       }

--- a/src/main/resources/data/explorerscompass/advancements/explorers_compass_cobweb.json
+++ b/src/main/resources/data/explorerscompass/advancements/explorers_compass_cobweb.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:cobweb"
+            "items": ["minecraft:cobweb"]
           }
         ]
       }

--- a/src/main/resources/data/explorerscompass/advancements/explorers_compass_cracked_stone_bricks.json
+++ b/src/main/resources/data/explorerscompass/advancements/explorers_compass_cracked_stone_bricks.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:cracked_stone_bricks"
+            "items": ["minecraft:cracked_stone_bricks"]
           }
         ]
       }


### PR DESCRIPTION
In Minecraft 1.19.2 (and likely every other version), picking up any item immediately unlocks the recipe for the explorer's compass. This is unintentional, since the advancements specify only certain items should unlock it. This PR fixes that.

According to the [Minecraft wiki](https://minecraft.fandom.com/wiki/Advancement/JSON_format#minecraft:inventory_changed), the objects in the `conditions.items` array should contain a key named "items", not "item", whose value is an array of strings, not a single string.