### PR TITLE
Fix compass spinning sometimes

### DIFF
--- a/src/main/java/com/chaosthedude/explorerscompass/ExplorersCompass.java
+++ b/src/main/java/com/chaosthedude/explorerscompass/ExplorersCompass.java
@@ -137,7 +137,7 @@ public class ExplorersCompass {
 					if (world.getGameTime() != lastUpdateTick) {
 						lastUpdateTick = world.getGameTime();
 						double d0 = amount - rotation;
-						d0 = d0 % (Math.PI * 2D);
+						d0 = Mth.positiveModulo(d0 + Math.PI, Math.PI * 2D) - Math.PI;
 						d0 = Mth.clamp(d0, -1.0D, 1.0D);
 						rota += d0 * 0.1D;
 						rota *= 0.8D;


### PR DESCRIPTION
As seen in the video below, whenever the player's yaw goes from positive to negative or the other way around (around the positive Z-direction), the compass does a full rotation.

https://github.com/MattCzyr/ExplorersCompass/assets/38467212/2a01bc90-f294-41e2-891f-387bd2d57d19

The solution is the same on fabric but using `MathHelper.floorMod()` like I've done in https://github.com/Giraaffes/ExplorersCompass/commit/9fd7284d840f77ab951521edba160c8f254aa875.