### PR TITLE
fix(network): allow logging into servers that don't have the mod

### DIFF
--- a/src/main/java/com/chaosthedude/explorerscompass/ExplorersCompass.java
+++ b/src/main/java/com/chaosthedude/explorerscompass/ExplorersCompass.java
@@ -74,7 +74,11 @@ public class ExplorersCompass {
 	}
 
 	private void commonSetup(FMLCommonSetupEvent event) {
-		network = ChannelBuilder.named(new ResourceLocation(ExplorersCompass.MODID, ExplorersCompass.MODID)).networkProtocolVersion(1).acceptedVersions(Channel.VersionTest.exact(1)).simpleChannel();
+		network = ChannelBuilder.named(new ResourceLocation(ExplorersCompass.MODID, ExplorersCompass.MODID))
+				.networkProtocolVersion(1)
+				.optionalServer()
+				.clientAcceptedVersions(Channel.VersionTest.exact(1))
+				.simpleChannel();
 
 		// Server packets
 		network.messageBuilder(CompassSearchPacket.class).encoder(CompassSearchPacket::toBytes).decoder(CompassSearchPacket::new).consumerMainThread(CompassSearchPacket::handle).add();


### PR DESCRIPTION
With the current networking setup players cannot login to any server that does not have ExplorersCompass.

This changes that to allow players to login to any server, but the server reject any client that does not have ExplorersCompass