### PR TITLE
Fix RandomSpreadSearchWorker missing western chunks

### DIFF
--- a/src/main/java/com/chaosthedude/explorerscompass/worker/RandomSpreadSearchWorker.java
+++ b/src/main/java/com/chaosthedude/explorerscompass/worker/RandomSpreadSearchWorker.java
@@ -63,12 +63,12 @@ public class RandomSpreadSearchWorker extends StructureSearchWorker<RandomSpread
 
 			z++;
 			if (z > length) {
-				z = -length;
 				x++;
 				if (x > length) {
-					x = -length;
 					length++;
+					x = -length;
 				}
+				z = -length;
 			}
 		} else {
 			if (!finished) {


### PR DESCRIPTION
This should also be backported to the versions using the optimized structure search, this seems to be 1.18.2, 1.19.2 and newer